### PR TITLE
fix: black run after checking out to ref branch

### DIFF
--- a/.github/workflows/autoblack.yml
+++ b/.github/workflows/autoblack.yml
@@ -21,10 +21,10 @@ jobs:
       - name: If needed, commit black changes to the pull request
         if: failure()
         run: |
-          black --line-length 120 .
           git config --global user.name 'autoblack'
           git config --global user.email 'ferdn4ndo@users.noreply.github.com'
           git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/$GITHUB_REPOSITORY
           git checkout $GITHUB_HEAD_REF
+          black --line-length 120 .
           git commit -am "fixup: Format Python code with Black"
           git push

--- a/src/app/clients/binance/binance_client.py
+++ b/src/app/clients/binance/binance_client.py
@@ -5,7 +5,6 @@ from app.clients.client_base import ClientBase
 
 
 class BinanceClient(ClientBase):
-
     URL_BASE = "https://api.binance.com/api/v3"  # https://binance-docs.github.io/apidocs/spot/en/
 
     PATH_EXCHANGE_INFO = "/exchangeInfo"  # https://binance-docs.github.io/apidocs/spot/en/#exchange-information

--- a/src/app/clients/client_base.py
+++ b/src/app/clients/client_base.py
@@ -2,7 +2,6 @@ from abc import ABC, abstractmethod
 
 
 class ClientBase(ABC):
-
     fetching_symbols = []
 
     @abstractmethod


### PR DESCRIPTION
Fixing black lint workflow, as it should be executed after checking out to the REF branch, otherwise it will fail to execute in case black modifies a file, as [occurred here](https://github.com/ferdn4ndo/candlestick-data-lake/actions/runs/10231617326/job/28307753176?pr=26):

![image](https://github.com/user-attachments/assets/a58a6ee0-89f7-4593-b0a8-4d32223e3d84)
