### PR TITLE
Devcontainer for VSCode

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,49 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/docker-existing-docker-compose
+{
+	"name": "candlestick-data-lake (devcontainer)",
+
+	// Update the 'dockerComposeFile' list if you have more compose files or use different names.
+	// The .devcontainer/docker-compose.yml file contains any overrides you need/want to make.
+	"dockerComposeFile": [
+		"../docker-compose.yml"
+	],
+
+	// The 'service' property is the name of the service for the container that VS Code should
+	// use. Update this value and .devcontainer/docker-compose.yml to the real service name.
+	"service": "app",
+
+	// The optional 'workspaceFolder' property is the path VS Code should open by default when
+	// connected. This is typically a file mount in .devcontainer/docker-compose.yml
+	// "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}"
+	"workspaceFolder": "/usr/src/app",
+
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"ms-python.debugpy"
+			]
+		}
+	}
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Uncomment the next line if you want start specific services in your Docker Compose config.
+	// "runServices": [],
+
+	// Uncomment the next line if you want to keep your containers running after VS Code shuts down.
+	// "shutdownAction": "none",
+
+	// Uncomment the next line to run commands after the container is created.
+	// "postCreateCommand": "cat /etc/os-release",
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as an existing user other than the container default. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "devcontainer"
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9.1-alpine
+FROM python:3.13.0-slim
 
 WORKDIR /usr/src
 
@@ -6,13 +6,13 @@ EXPOSE 8888
 
 RUN mkdir ./app
 
-RUN apk add --no-cache \
+RUN apt-get update && apt-get install -y \
         curl \
-        mariadb-dev \
-        build-base \
-        linux-headers \
-        libffi-dev
-
+        libmariadb-dev \
+        build-essential \
+        linux-headers-generic \
+        libffi-dev \
+        && rm -rf /var/lib/apt/lists/*
 COPY ./src/requirements.txt .
 COPY ./src/requirements.dev.txt .
 RUN pip3 install --no-cache-dir -r requirements.txt

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,11 @@ services:
     volumes:
       - csdl-db-volume:/var/lib/mysql
     restart: always
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   app:
     container_name: csdl-app
@@ -18,11 +23,13 @@ services:
       - .env
     ports:
       - "8888:8888"
+      - "5678:5678"
     volumes:
       - ./src/app:/usr/src/app
     command: "/usr/src/entrypoint.dev.sh"
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     stdin_open: true
     tty: true
 

--- a/src/entrypoint.dev.sh
+++ b/src/entrypoint.dev.sh
@@ -6,14 +6,11 @@ cd ..
 
 pip install -r requirements.dev.txt
 
-until nc -z -v -w30 db 3306
-do
-    echo "Waiting for database connection..."
-    sleep 2
-done
-
 cd app || { echo "Unable to navigate to application folder" 1>&2; exit 1; }
 
 alembic upgrade head
 
-python -m tornado.autoreload main.py
+python \
+    -m debugpy --listen 0.0.0.0:5678\
+    -m tornado.autoreload \
+    main.py

--- a/src/requirements.dev.txt
+++ b/src/requirements.dev.txt
@@ -1,3 +1,4 @@
 black==24.3.0
+debugpy==1.8.7
 ipython==8.10.0
 pycodestyle==2.7.0


### PR DESCRIPTION
Add devcontainer for VSCode to the project. Supporting debugger.

- Add devcontainers config
- Add debugpy install in requirements.dev.txt and execution in entrypoint.dev.sh
- Use slim image instead alpine  in Dockercompose because devcontainer don't support alpine images.
- Changed db health check mechanism (slim image don't have "nc" command)